### PR TITLE
Emo 4801

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -310,6 +310,9 @@
                                 </mapping>
                                 <!-- Helper jar that gets added to Cassandra's classpath and wraps its main() method. -->
                                 <mapping>
+                                    <filemode>755</filemode>
+                                    <username>cassandra</username>
+                                    <groupname>cassandra</groupname>
                                     <directory>/usr/share/cassandra/lib/</directory>
                                     <sources>
                                         <source>


### PR DESCRIPTION
Fixes Priam and Cassandra RPM's conflict due to RPM 4.11.1.

This shouldn't be a long-term thing since upgrading Cassandra could potentially break it again. Basically we should bake AMI's :D and stop installing RPMs and relying on whatever base packages Amazon provides to us, which they can change more or less on a whim.
