### PR TITLE
Back out OOM-Killer adjustment code.

### DIFF
--- a/core/src/main/java/com/netflix/priam/cassandra/NFThinCassandraDaemon.java
+++ b/core/src/main/java/com/netflix/priam/cassandra/NFThinCassandraDaemon.java
@@ -1,13 +1,10 @@
 package com.netflix.priam.cassandra;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import com.netflix.priam.utils.SystemUtils;
 import org.apache.cassandra.thrift.CassandraDaemon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 
 public class NFThinCassandraDaemon extends CassandraDaemon {
@@ -37,7 +34,6 @@ public class NFThinCassandraDaemon extends CassandraDaemon {
     @Override
     public void init(String[] args) throws IOException {
         setPriamProperties();
-        protectFromOomKiller();
         super.init(args);
     }
 
@@ -69,20 +65,6 @@ public class NFThinCassandraDaemon extends CassandraDaemon {
 
         if (isReplace) {
             System.setProperty("cassandra.replace_token", token);
-        }
-    }
-
-    private void protectFromOomKiller() {
-        File oomAdj = new File("/proc/self/oom_adj");
-
-        if (!oomAdj.exists()) {
-            return;
-        }
-
-        try {
-            Files.write("-16", oomAdj, Charsets.UTF_8);
-        } catch (IOException e) {
-            logger.warn("Failed to write OOM adjust.", e);
         }
     }
 }


### PR DESCRIPTION
It appears that you must be root to give yourself a negative oom_adj score and Cassandra generally doesn't run as root.  So this code had no effect.  A better approach is to modify oom_score_adj in the init.d scripts that start Cassandra, for example in `/etc/default/cassandra`.
