### PR TITLE
Fix yum deploy step to refer to the correct rpm artifact.

### DIFF
--- a/yum/pom.xml
+++ b/yum/pom.xml
@@ -105,8 +105,8 @@
                                     <s3RepositoryPath>${yumrepo.s3RepositoryPath}</s3RepositoryPath>
                                     <artifactItems>
                                         <artifactItem>
-                                            <groupId>com.bazaarvoice.priam</groupId>
-                                            <artifactId>priam</artifactId>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>${project.artifactId}</artifactId>
                                             <version>${project.version}</version>
                                             <type>rpm</type>
                                             <classifier>rpm</classifier>


### PR DESCRIPTION
Broken during the refactoring for Cassandra 1.2.
