### PR TITLE
EMO-5319 - Updating our SimpleDB logic to use test-and-set

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
@@ -113,7 +113,7 @@ public class SDBInstanceData {
      * @param consistentRead  Whether to require strong consistency on the read
      * @return the node with the given {@code id}, or {@code null} if no such node exists
      */
-    public PriamInstance getInstance(String app, int id,  boolean consistentRead) {
+    public PriamInstance getInstance(String app, int id, boolean consistentRead) {
         AmazonSimpleDB simpleDBClient = getSimpleDBClient();
         SelectRequest request = new SelectRequest(getInstanceQuery(app, id));
         request.setConsistentRead(consistentRead);
@@ -133,7 +133,7 @@ public class SDBInstanceData {
      * @return the set of all instances in the given {@code app}
      */
     public Set<PriamInstance> getAllIds(String app) {
-        return getAllIds(app, false);
+        return getAllIds(app, true);
     }
 
     /**

--- a/priam/src/main/java/com/netflix/priam/identity/DoubleRing.java
+++ b/priam/src/main/java/com/netflix/priam/identity/DoubleRing.java
@@ -89,7 +89,7 @@ public class DoubleRing {
             String token = tokenManager.createToken(newSlot, newRingSize, amazonConfiguration.getRegionName());
             instanceRegistry.create(priamInstance.getApp(),
                     regionOffsetHash + newSlot,
-                    "new_slot",
+                    PriamInstance.NEW_INSTANCE_PLACEHOLDER_ID,
                     amazonConfiguration.getPrivateHostName(),
                     amazonConfiguration.getPrivateIP(),
                     priamInstance.getAvailabilityZone(),

--- a/priam/src/main/java/com/netflix/priam/identity/IPriamInstanceRegistry.java
+++ b/priam/src/main/java/com/netflix/priam/identity/IPriamInstanceRegistry.java
@@ -33,6 +33,13 @@ public interface IPriamInstanceRegistry {
     PriamInstance create(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token);
 
     /**
+     * Updates the value of an existing registry entry, provided that the current value matches what the caller expects (this acts as a basic test-and-set mechanism for updates)
+     *
+     * @return the new node, or null if it failed to acquire the slot
+     */
+    PriamInstance acquireSlotId(int slotId, String expectedInstanceId, String app, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token);
+
+    /**
      * Delete the server node from the registry
      *
      * @param inst the node to delete

--- a/priam/src/main/java/com/netflix/priam/identity/IPriamInstanceRegistry.java
+++ b/priam/src/main/java/com/netflix/priam/identity/IPriamInstanceRegistry.java
@@ -33,7 +33,8 @@ public interface IPriamInstanceRegistry {
     PriamInstance create(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token);
 
     /**
-     * Updates the value of an existing registry entry, provided that the current value matches what the caller expects (this acts as a basic test-and-set mechanism for updates)
+     * Updates the value of an existing registry entry, provided that the current value matches what the caller expects
+     * (this acts as a basic test-and-set mechanism for updates)
      *
      * @return the new node, or null if it failed to acquire the slot
      */

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -17,6 +17,7 @@ package com.netflix.priam.identity;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.config.AmazonConfiguration;
@@ -107,34 +108,60 @@ public class InstanceIdentity {
             List<String> asgInstanceIDs = membership.getAutoScaleGroupMembership();
             // Sleep random interval - 10 to 15 sec
             sleeper.sleep(new Random().nextInt(5000) + 10000);
-            for (final PriamInstance deadInstance : priamInstances) {
-                // Only consider instances that are in the same availability zone but not in the auto-scale group
-                if (!deadInstance.getAvailabilityZone().equals(amazonConfiguration.getAvailabilityZone())
-                        || asgInstanceIDs.contains(deadInstance.getInstanceId())) {
-                    // This instance isn't really dead.
-                    continue;
+
+            // Build a list of dead instances that we might replace
+            boolean healthyNodePresent = false;
+            List<PriamInstance> deadInstances = Lists.newArrayList();
+            for (final PriamInstance instance : priamInstances) {
+                if (!asgInstanceIDs.contains(instance.getInstanceId())) {
+                    // The provided instance was not found in our ASG - it's dead, just do an additional check to see if it's in our availability zone (in which case we are eligible to replace it)
+                    if (instance.getAvailabilityZone().equals(amazonConfiguration.getAvailabilityZone())) {
+                        // *Clang* Bring out your dead!
+                        deadInstances.add(instance);
+                    }
+                } else {
+                    // Flag whether there is a healthy node present in our ASG (it doesn't matter if it's in our availability zone or not)
+                    healthyNodePresent = true;
                 }
-
-                // If we're here, it means we had a record in our instance registry pointing to something in our same availability zone, but that isn't
-                // a current part of our ASG.  This would normally mean the node has died.
-
-                logger.info("Found dead instance {} with token {}.", deadInstance.getInstanceId(), deadInstance.getToken());
-                instanceRegistry.delete(deadInstance);
-
-                logger.info("Trying to grab slot {} in availability zone {} with token {}", deadInstance.getId(), deadInstance.getAvailabilityZone(), deadInstance.getToken());
-                isReplace = true;
-                replacedIp = deadInstance.getHostIP();
-                return instanceRegistry.create(
-                        cassandraConfiguration.getClusterName(),
-                        deadInstance.getId(),
-                        amazonConfiguration.getInstanceID(),
-                        amazonConfiguration.getPrivateHostName(),
-                        amazonConfiguration.getPrivateIP(),
-                        amazonConfiguration.getAvailabilityZone(),
-                        deadInstance.getVolumes(),
-                        deadInstance.getToken());
             }
-            return null;
+
+            // No dead instances available; return and try something else
+            if (deadInstances.isEmpty()) {
+                return null;
+            }
+
+            // Log an error message if our auto-scale group doesn't have any active nodes. At this point we're doomed to fail, but instead of getting cute and trying to repair the state on our own,
+            // we alert the engineer so that they can fix the underlying issue.
+            if (healthyNodePresent == false) {
+                logger.error("Attempting to replace dead tokens in a cluster where no healthy nodes exist. Cassandra is likely to deadlock at startup. Consider clearing the SimpleDB data " +
+                        "for this cluster");
+            }
+
+            // At this point we have at least one slot associated with an invalid instance. Unfortunately, deadInstances will be a sorted list, and if every new instance tries to grab the first
+            // entry on it then they'll all be contending for the same slot. We have mechanisms in place to ensure that this doesn't create an outright error condition, but it's still very
+            // inefficient, as servers may have to retry multiple times before they can successfully claim a slot. To reduce this contention, we have each new instance select an available deadInstance
+            // slot at random, allowing for more than one instance to succeed on its first try.
+            String newInstanceId = amazonConfiguration.getInstanceID();
+            int newInstanceHash = Math.abs(newInstanceId.hashCode());
+            int randomIndex = (newInstanceHash % deadInstances.size());
+            PriamInstance deadInstance = deadInstances.get(randomIndex);
+
+            logger.info("Found dead instance {} with token {} - trying to grab its slot.", deadInstance.getInstanceId(), deadInstance.getToken());
+            PriamInstance newInstance = instanceRegistry.acquireSlotId(deadInstance.getId(), deadInstance.getInstanceId(), cassandraConfiguration.getClusterName(),
+                    newInstanceId, amazonConfiguration.getPrivateHostName(), amazonConfiguration.getPrivateIP(), amazonConfiguration.getAvailabilityZone(),
+                    deadInstance.getVolumes(), deadInstance.getToken());
+            if (newInstance != null) {
+                // We succeeded! Flag the instance we replaced (if we replaced an actual functioning instance and not just a placeholder instance, such as those populated by /double_ring).
+                if (!deadInstance.getInstanceId().equals(PriamInstance.NEW_INSTANCE_PLACEHOLDER_ID)) {
+                    isReplace = true;
+                    replacedIp = deadInstance.getHostIP();
+                }
+                return newInstance;
+            }
+
+            // Failed to acquire the slot . . throw an exception so that we retry the operation
+            logger.info("New instance {} failed to acquire slot {}", newInstanceId, deadInstance.getId());
+            throw new Exception("Failed to acquire token");
         }
 
         public void forEachExecution() {

--- a/priam/src/main/java/com/netflix/priam/identity/PriamInstance.java
+++ b/priam/src/main/java/com/netflix/priam/identity/PriamInstance.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PriamInstance implements Serializable, Comparable<PriamInstance> {
+    public static final String NEW_INSTANCE_PLACEHOLDER_ID = "new_slot";
+
     private static final long serialVersionUID = 5606412386974488659L;
     private String hostname;
     private long updatetime;

--- a/priam/src/main/java/com/netflix/priam/utils/RetryableCallable.java
+++ b/priam/src/main/java/com/netflix/priam/utils/RetryableCallable.java
@@ -18,6 +18,8 @@ package com.netflix.priam.utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 
@@ -67,7 +69,10 @@ public abstract class RetryableCallable<T> implements Callable<T> {
                     throw e;
                 }
                 if (logErrors) {
+                    StringWriter stringWriter = new StringWriter();
+                    e.printStackTrace(new PrintWriter(stringWriter, true));
                     logger.error("Retry #{} for: {}", retry, e.getMessage());
+                    logger.error("Details: " + stringWriter.getBuffer().toString());
                 }
                 Thread.sleep(waitTime);
             } finally {

--- a/priam/src/test/java/com/netflix/priam/FakePriamInstanceRegistry.java
+++ b/priam/src/test/java/com/netflix/priam/FakePriamInstanceRegistry.java
@@ -36,7 +36,8 @@ public class FakePriamInstanceRegistry implements IPriamInstanceRegistry {
 
     @Override
     public PriamInstance acquireSlotId(int slotId, String expectedInstanceId, String app, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token) {
-        // we can acquire the slot if 1.) the expected instance ID is null and the slot ID does not currently exist or 2.) the expected instance ID is valid, the slot exists, and the values match
+        // We can acquire the slot if 1.) the expected instance ID is null and the slot ID does not currently exist or
+        // 2.) the expected instance ID is valid, the slot exists, and the values match
         boolean canAcquire = (expectedInstanceId == null && !instances.containsKey(slotId)) ||
                 (expectedInstanceId != null && instances.containsKey(slotId) && instances.get(slotId).getInstanceId() == expectedInstanceId);
         if (canAcquire) {

--- a/priam/src/test/java/com/netflix/priam/TestAmazonConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/TestAmazonConfiguration.java
@@ -14,6 +14,6 @@ public class TestAmazonConfiguration extends AmazonConfiguration {
         setUsableAvailabilityZones(Arrays.asList("az1", "az2", "az3"));
         setPrivateHostName(instanceId);
         setSecurityGroupName(clusterName);
-        setPrivateIP(null);
+        setPrivateIP("fakeIp");
     }
 }

--- a/priam/src/test/java/com/netflix/priam/identity/DoubleRingTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/DoubleRingTest.java
@@ -38,7 +38,7 @@ public class DoubleRingTest extends InstanceTestUtils {
             int id = ins.getId() - TokenManager.regionOffset(amazonConfiguration.getRegionName());
             //System.out.println(ins);
             if (0 != id % 2) {
-                assertEquals(ins.getInstanceId(), "new_slot");
+                assertEquals(ins.getInstanceId(), PriamInstance.NEW_INSTANCE_PLACEHOLDER_ID);
             }
             // Verify that instances are spread across AZs evenly and in sequence.
             assertEquals(ins.getAvailabilityZone(), doubled.get((i + numZones) % numZones).getAvailabilityZone());


### PR DESCRIPTION
Updating our SimpleDB logic to use test-and-set to acquire a token slot instead of blindly deleting and inserting. Includes associated changes to ensure that the correct 'replace' value is passed into Cassandra and some preemptive logging of a bad startup state.