### PR TITLE
EMO-6342: Added support for multiple data centers within a region

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
@@ -33,6 +33,7 @@ import com.amazonaws.services.simpledb.model.UpdateCondition;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.config.AmazonConfiguration;
+import com.netflix.priam.identity.Location;
 import com.netflix.priam.identity.PriamInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -241,7 +242,7 @@ public class SDBInstanceData {
         attrs.add(new ReplaceableAttribute(Attributes.AVAILABILITY_ZONE, instance.getAvailabilityZone(), true));
         attrs.add(new ReplaceableAttribute(Attributes.ELASTIC_IP, instance.getHostIP(), true));
         attrs.add(new ReplaceableAttribute(Attributes.HOSTNAME, instance.getHostName(), true));
-        attrs.add(new ReplaceableAttribute(Attributes.LOCATION, instance.getRegionName(), true));
+        attrs.add(new ReplaceableAttribute(Attributes.LOCATION, instance.getLocation().toString(), true));
         attrs.add(new ReplaceableAttribute(Attributes.UPDATE_TS, Long.toString(instance.getUpdatetime()), true));
         return attrs;
     }
@@ -275,7 +276,7 @@ public class SDBInstanceData {
                     ins.setHost(att.getValue());
                     break;
                 case Attributes.LOCATION:
-                    ins.setRegionName(att.getValue());
+                    ins.setLocation(Location.from(att.getValue()));
                     break;
                 case Attributes.UPDATE_TS:
                     ins.setUpdatetime(Long.parseLong(att.getValue()));

--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceRegistry.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceRegistry.java
@@ -21,6 +21,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.config.AmazonConfiguration;
 import com.netflix.priam.identity.IPriamInstanceRegistry;
+import com.netflix.priam.identity.Location;
 import com.netflix.priam.identity.PriamInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,12 +37,12 @@ import java.util.Map;
 public class SDBInstanceRegistry implements IPriamInstanceRegistry {
     private static final Logger logger = LoggerFactory.getLogger(SDBInstanceRegistry.class);
 
-    private final AmazonConfiguration amazonConfiguration;
+    private final Location location;
     private final SDBInstanceData dao;
 
     @Inject
-    public SDBInstanceRegistry(AmazonConfiguration amazonConfiguration, SDBInstanceData dao) {
-        this.amazonConfiguration = amazonConfiguration;
+    public SDBInstanceRegistry(Location location, SDBInstanceData dao) {
+        this.location = location;
         this.dao = dao;
     }
 
@@ -63,7 +64,7 @@ public class SDBInstanceRegistry implements IPriamInstanceRegistry {
     @Override
     public PriamInstance acquireSlotId(int slotId, String expectedInstanceId, String app, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token) {
         try {
-            PriamInstance ins = PriamInstance.from(app, slotId, instanceID, hostname, ip, rac, volumes, token, amazonConfiguration.getRegionName());
+            PriamInstance ins = PriamInstance.from(app, slotId, instanceID, hostname, ip, rac, volumes, token, location);
             dao.registerInstance(ins, expectedInstanceId);
             // Only return a result if we successfully overwrote the previous value; otherwise return null to indicate failure
             PriamInstance storedInstance = dao.getInstance(ins.getApp(), ins.getId(), true);

--- a/priam/src/main/java/com/netflix/priam/config/CassandraConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/CassandraConfiguration.java
@@ -41,6 +41,9 @@ public class CassandraConfiguration {
     private String clusterName;
 
     @JsonProperty
+    private String dataCenterSuffix;
+
+    @JsonProperty
     private String dataLocation;
 
     @JsonProperty
@@ -218,6 +221,10 @@ public class CassandraConfiguration {
 
     public String getClusterName() {
         return clusterName;
+    }
+
+    public String getDataCenterSuffix() {
+        return dataCenterSuffix;
     }
 
     public String getDataLocation() {
@@ -418,6 +425,10 @@ public class CassandraConfiguration {
 
     public void setClusterName(String clusterName) {
         this.clusterName = clusterName;
+    }
+
+    public void setDataCenterSuffix(String dataCenterSuffix) {
+        this.dataCenterSuffix = dataCenterSuffix;
     }
 
     public void setDataLocation(String dataLocation) {

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamGuiceModule.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamGuiceModule.java
@@ -34,8 +34,10 @@ import com.netflix.priam.config.MonitoringConfiguration;
 import com.netflix.priam.config.PriamConfiguration;
 import com.netflix.priam.config.ZooKeeperConfiguration;
 import com.netflix.priam.dropwizard.managers.ServiceRegistryManager;
+import com.netflix.priam.identity.ConfigFileLocation;
 import com.netflix.priam.identity.IMembership;
 import com.netflix.priam.identity.IPriamInstanceRegistry;
+import com.netflix.priam.identity.Location;
 import com.netflix.priam.local.LocalMembership;
 import com.netflix.priam.utils.Sleeper;
 import com.netflix.priam.utils.ThreadSleeper;
@@ -84,6 +86,7 @@ public class PriamGuiceModule extends AbstractModule {
         }
         bind(AWSCredentialsProvider.class).to(DefaultAWSCredentialsProviderChain.class).asEagerSingleton();
 
+        bind(Location.class).to(ConfigFileLocation.class).asEagerSingleton();
         bind(TokenManager.class).toProvider(TokenManagerProvider.class);
         bind(Sleeper.class).to(ThreadSleeper.class).asEagerSingleton();
 

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
@@ -213,7 +213,7 @@ public class StandardTuner implements CassandraTuner {
         if (Strings.isNullOrEmpty(dcSuffix)) {
             properties.remove("dc_suffix");
         } else {
-            properties.put("dc_suffix", "_" + dcSuffix);
+            properties.put("dc_suffix", dcSuffix);
         }
 
         if (logger.isInfoEnabled()) {

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
@@ -6,6 +6,7 @@ import com.google.inject.Inject;
 import com.netflix.priam.config.BackupConfiguration;
 import com.netflix.priam.config.CassandraConfiguration;
 import com.netflix.priam.utils.CassandraTuner;
+import org.apache.cassandra.locator.SnitchProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
@@ -15,8 +16,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -100,6 +104,8 @@ public class StandardTuner implements CassandraTuner {
         yaml.dump(map, new FileWriter(yamlFile));
 
         configureCommitLogBackups();
+
+        writeCassandraSnitchProperties();
     }
 
     /**
@@ -185,6 +191,46 @@ public class StandardTuner implements CassandraTuner {
             String cassVal = entry.getValue();
             logger.info("Updating yaml: CassKey[{}], Val[{}]", cassKey, cassVal);
             put(map, cassKey, cassVal);
+        }
+    }
+
+    private void writeCassandraSnitchProperties() {
+        String rackdcPropFileName = cassandraConfiguration.getCassHome() + "/conf/" + SnitchProperties.RACKDC_PROPERTY_FILENAME;
+        File rackdcPropFile = new File(rackdcPropFileName);
+        Properties properties = new Properties();
+
+        // Read the existing properties, if any.
+        if (rackdcPropFile.exists()) {
+            try (Reader reader = new FileReader(rackdcPropFile)) {
+                properties.load(reader);
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to read " + SnitchProperties.RACKDC_PROPERTY_FILENAME, e);
+            }
+        }
+
+        // Set the "dc_suffix" property if there is one configured
+        String dcSuffix = cassandraConfiguration.getDataCenterSuffix();
+        if (Strings.isNullOrEmpty(dcSuffix)) {
+            properties.remove("dc_suffix");
+        } else {
+            properties.put("dc_suffix", "_" + dcSuffix);
+        }
+
+        if (logger.isInfoEnabled()) {
+            if (properties.isEmpty()) {
+                logger.info("Updating {}: no properties", SnitchProperties.RACKDC_PROPERTY_FILENAME);
+            } else {
+                for (Map.Entry entry : properties.entrySet()) {
+                    logger.info("Updating {}: {}={}", SnitchProperties.RACKDC_PROPERTY_FILENAME, entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        // Write the updated properties back
+        try (Writer writer = new FileWriter(rackdcPropFile)) {
+            properties.store(writer, "");
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to write " + SnitchProperties.RACKDC_PROPERTY_FILENAME, e);
         }
     }
 

--- a/priam/src/main/java/com/netflix/priam/identity/ConfigFileLocation.java
+++ b/priam/src/main/java/com/netflix/priam/identity/ConfigFileLocation.java
@@ -1,0 +1,51 @@
+package com.netflix.priam.identity;
+
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
+import com.netflix.priam.config.AmazonConfiguration;
+import com.netflix.priam.config.CassandraConfiguration;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Location implementation which gets its attributes directly from Priam configuration files.  This is necessary
+ * because the Location is generated as part of Guice injection but the {@link AmazonConfiguration} singleton isn't
+ * fully populated until after injection is complete.  Since the configuration's region name likely won't be set at that
+ * construction an implementation is required which gets the region name from the configuration directly.
+ */
+public class ConfigFileLocation extends Location {
+
+    private final AmazonConfiguration amazonConfiguration;
+    private final String dataCenterSuffix;
+
+    @Inject
+    public ConfigFileLocation(AmazonConfiguration amazonConfiguration, CassandraConfiguration cassandraConfiguration) {
+        this.amazonConfiguration = checkNotNull(amazonConfiguration, "Amazon configuration is required");
+        checkNotNull(cassandraConfiguration, "Cassandra configuration is required");
+
+        // Amazon config will ensure the region name is set, but validate the data center suffix.
+        dataCenterSuffix = Strings.nullToEmpty(cassandraConfiguration.getDataCenterSuffix());
+        checkArgument(!dataCenterSuffix.contains("/"), "Data center suffix cannot include '/'");
+    }
+
+    @Override
+    public String getRegionName() {
+        return amazonConfiguration.getRegionName();
+    }
+
+    @Override
+    public String getDataCenterSuffix() {
+        return dataCenterSuffix;
+    }
+
+    /**
+     * Override serializer to write as a simple location.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeObject(new SimpleLocation(getRegionName(), getDataCenterSuffix()));
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -335,6 +335,12 @@ public class InstanceIdentity {
 
         @Override
         public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof LocationAZPair)) {
+                return false;
+            }
             LocationAZPair other = (LocationAZPair) o;
             return location.equals(other.location) && availabilityZone.equals(other.availabilityZone);
         }

--- a/priam/src/main/java/com/netflix/priam/identity/Location.java
+++ b/priam/src/main/java/com/netflix/priam/identity/Location.java
@@ -1,0 +1,70 @@
+package com.netflix.priam.identity;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Location is a representation of where this data center is within the cluster.  It contains two elements:
+ *
+ * <ol>
+ *     <li>The AWS region</li>
+ *     <li>A suffix for the data center, which can be used to create multiple distinct rings for the cluster
+ *         within the same data center</li>
+ * </ol>
+ */
+abstract public class Location implements Serializable {
+
+    /**
+     * Static helper method to create a Location from the string produced by {@link #toString()}.
+     */
+    public static Location from(String locationString) {
+        String[] parts = locationString.split("/");
+        checkArgument(parts.length <= 2, "Invalid location string, too many path elements");
+        String regionName = parts[0];
+        String dataCenterSuffix = parts.length == 1 ? "" : parts[1];
+        return new SimpleLocation(regionName, dataCenterSuffix);
+    }
+
+    abstract public String getRegionName();
+
+    abstract public String getDataCenterSuffix();
+
+    @Override
+    public String toString() {
+        // If there is no data center suffix then the location is simply the region name.  This is both for readability
+        // and to maintain backwards compatibility with clusters created using an older version of Priam which only
+        // supported a single data center per region.
+        if (getDataCenterSuffix().isEmpty()) {
+            return getRegionName();
+        }
+        return Joiner.on('/').join(getRegionName(), getDataCenterSuffix());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Location)) {
+            return false;
+        }
+
+        Location location = (Location) o;
+
+        return getRegionName().equals(location.getRegionName()) && getDataCenterSuffix().equals(location.getDataCenterSuffix());
+    }
+
+    @Override
+    public int hashCode() {
+        // For backwards compatibility with pre-existing token logic if there is no data center suffix return the hash
+        // of the region name.
+        if (getDataCenterSuffix().isEmpty()) {
+            return getRegionName().hashCode();
+        }
+        return Objects.hashCode(getRegionName(), getDataCenterSuffix());
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/identity/PriamInstance.java
+++ b/priam/src/main/java/com/netflix/priam/identity/PriamInstance.java
@@ -20,12 +20,12 @@ public class PriamInstance implements Serializable, Comparable<PriamInstance> {
     private String instanceId;
     private String availabilityZone;
     private String hostIp;
-    private String regionName;
+    private Location location;
     private String token;
     //Handles Storage objects
     private Map<String, Object> volumes;
 
-    public static PriamInstance from(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token, String regionName) {
+    public static PriamInstance from(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token, Location location) {
         Map<String, Object> v = (volumes == null) ? new HashMap<String, Object>() : volumes;
         PriamInstance ins = new PriamInstance();
         ins.setApp(app);
@@ -34,7 +34,7 @@ public class PriamInstance implements Serializable, Comparable<PriamInstance> {
         ins.setHostIP(ip);
         ins.setId(id);
         ins.setInstanceId(instanceID);
-        ins.setRegionName(regionName);
+        ins.setLocation(location);
         ins.setToken(token);
         ins.setVolumes(v);
         return ins;
@@ -113,16 +113,16 @@ public class PriamInstance implements Serializable, Comparable<PriamInstance> {
     @Override
     public String toString() {
         return String.format("Hostname: %s, InstanceId: %s, APP_NAME: %s, RAC: %s, Location: %s, Id: %s, Token: %s, Updated: %s",
-                getHostName(), getInstanceId(), getApp(), getAvailabilityZone(), getRegionName(), getId(), getToken(),
+                getHostName(), getInstanceId(), getApp(), getAvailabilityZone(), getLocation(), getId(), getToken(),
                 new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(getUpdatetime()));
     }
 
-    public String getRegionName() {
-        return regionName;
+    public Location getLocation() {
+        return location;
     }
 
-    public void setRegionName(String regionName) {
-        this.regionName = regionName;
+    public void setLocation(Location location) {
+        this.location = location;
     }
 
     public long getUpdatetime() {

--- a/priam/src/main/java/com/netflix/priam/identity/SimpleLocation.java
+++ b/priam/src/main/java/com/netflix/priam/identity/SimpleLocation.java
@@ -1,0 +1,34 @@
+package com.netflix.priam.identity;
+
+import com.google.common.base.Strings;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Simple POJO Location implementation.
+ */
+public class SimpleLocation extends Location {
+
+    private final String regionName;
+    private final String dataCenterSuffix;
+
+    public SimpleLocation(String regionName, String dataCenterSuffix) {
+        checkArgument(!Strings.isNullOrEmpty(regionName), "Region name must be a non-empty string");
+        checkArgument(dataCenterSuffix != null, "Data center suffix cannot be null");
+        checkArgument(!regionName.contains("/"), "Region name cannot include '/'");
+        checkArgument(!dataCenterSuffix.contains("/"), "Data center suffix cannot include '/'");
+
+        this.regionName = regionName;
+        this.dataCenterSuffix = dataCenterSuffix;
+    }
+
+    @Override
+    public String getRegionName() {
+        return regionName;
+    }
+
+    @Override
+    public String getDataCenterSuffix() {
+        return dataCenterSuffix;
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/utils/BOPTokenManager.java
+++ b/priam/src/main/java/com/netflix/priam/utils/BOPTokenManager.java
@@ -18,6 +18,7 @@ package com.netflix.priam.utils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.Ordering;
+import com.netflix.priam.identity.Location;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.BytesToken;
 import org.apache.cassandra.dht.Token;
@@ -92,8 +93,8 @@ public class BOPTokenManager extends TokenManager {
     }
 
     @Override
-    public String createToken(int mySlot, int totalCount, String region) {
-        return partitioner.getTokenFactory().toString(initialToken(totalCount, mySlot, regionOffset(region)));
+    public String createToken(int mySlot, int totalCount, Location location) {
+        return partitioner.getTokenFactory().toString(initialToken(totalCount, mySlot, locationOffset(location)));
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/utils/BigIntegerTokenManager.java
+++ b/priam/src/main/java/com/netflix/priam/utils/BigIntegerTokenManager.java
@@ -20,6 +20,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
+import com.netflix.priam.identity.Location;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -71,8 +72,8 @@ public class BigIntegerTokenManager extends TokenManager {
     }
 
     @Override
-    public String createToken(int mySlot, int totalCount, String region) {
-        return initialToken(totalCount, mySlot, regionOffset(region)).toString();
+    public String createToken(int mySlot, int totalCount, Location location) {
+        return initialToken(totalCount, mySlot, locationOffset(location)).toString();
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
+++ b/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.priam.utils;
 
+import com.netflix.priam.identity.Location;
+
 import java.util.List;
 
 public abstract class TokenManager {
@@ -24,13 +26,13 @@ public abstract class TokenManager {
      * @param mySlot                         -- Slot where this instance has to be.
      * @param availabilityZones              -- The number of AvailabilityZones
      * @param availabilityZoneMembershipSize -- number of members in the availabilityZone
-     * @param region                         -- name of the DC where it this token is created.
+     * @param location                       -- location where this token is created.
      */
-    public String createToken(int mySlot, int availabilityZones, int availabilityZoneMembershipSize, String region) {
-        return createToken(mySlot, availabilityZones * availabilityZoneMembershipSize, region);
+    public String createToken(int mySlot, int availabilityZones, int availabilityZoneMembershipSize, Location location) {
+        return createToken(mySlot, availabilityZones * availabilityZoneMembershipSize, location);
     }
 
-    public abstract String createToken(int mySlot, int totalCount, String region);
+    public abstract String createToken(int mySlot, int totalCount, Location location);
 
     public abstract String findClosestToken(String tokenToSearch, List<String> tokenList);
 
@@ -40,9 +42,9 @@ public abstract class TokenManager {
     public abstract String sanitizeToken(String jmxTokenString);
 
     /**
-     * Create an offset to add to token values by hashing the region name.
+     * Create an offset to add to token values by hashing the location.
      */
-    public static int regionOffset(String region) {
-        return Math.abs(region.hashCode());
+    public static int locationOffset(Location location) {
+        return Math.abs(location.hashCode());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/FakePriamInstanceRegistry.java
+++ b/priam/src/test/java/com/netflix/priam/FakePriamInstanceRegistry.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.netflix.priam.config.AmazonConfiguration;
 import com.netflix.priam.identity.IPriamInstanceRegistry;
+import com.netflix.priam.identity.Location;
 import com.netflix.priam.identity.PriamInstance;
 
 import java.util.ArrayList;
@@ -12,11 +13,11 @@ import java.util.Map;
 
 public class FakePriamInstanceRegistry implements IPriamInstanceRegistry {
     private final Map<Integer, PriamInstance> instances = Maps.newHashMap();
-    private final AmazonConfiguration config;
+    private final Location location;
 
     @Inject
-    public FakePriamInstanceRegistry(AmazonConfiguration config) {
-        this.config = config;
+    public FakePriamInstanceRegistry(Location location) {
+        this.location = location;
     }
 
     @Override
@@ -49,7 +50,7 @@ public class FakePriamInstanceRegistry implements IPriamInstanceRegistry {
             ins.setInstanceId(instanceID);
             ins.setToken(token);
             ins.setVolumes(volumes);
-            ins.setRegionName(config.getRegionName());
+            ins.setLocation(location);
 
             instances.put(slotId, ins);
             return ins;

--- a/priam/src/test/java/com/netflix/priam/TestModule.java
+++ b/priam/src/test/java/com/netflix/priam/TestModule.java
@@ -8,8 +8,10 @@ import com.google.inject.AbstractModule;
 import com.netflix.priam.config.AmazonConfiguration;
 import com.netflix.priam.config.BackupConfiguration;
 import com.netflix.priam.config.CassandraConfiguration;
+import com.netflix.priam.identity.ConfigFileLocation;
 import com.netflix.priam.identity.IMembership;
 import com.netflix.priam.identity.IPriamInstanceRegistry;
+import com.netflix.priam.identity.Location;
 import com.netflix.priam.utils.FakeSleeper;
 import com.netflix.priam.utils.Sleeper;
 import com.netflix.priam.utils.TokenManager;
@@ -29,5 +31,6 @@ public class TestModule extends AbstractModule {
         bind(AWSCredentialsProvider.class).toInstance(new StaticCredentialsProvider(new AnonymousAWSCredentials()));
         bind(TokenManager.class).toProvider(TokenManagerProvider.class);
         bind(Sleeper.class).to(FakeSleeper.class).asEagerSingleton();
+        bind(Location.class).to(ConfigFileLocation.class).asEagerSingleton();
     }
 }

--- a/priam/src/test/java/com/netflix/priam/identity/DoubleRingTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/DoubleRingTest.java
@@ -1,10 +1,15 @@
 package com.netflix.priam.identity;
 
+import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
+import com.google.common.collect.SetMultimap;
 import com.netflix.priam.utils.TokenManager;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -14,19 +19,31 @@ public class DoubleRingTest extends InstanceTestUtils {
     @Test
     public void testDouble() throws Exception {
         createInstances();
-        int originalSize = instanceRegistry.getAllIds(cassandraConfiguration.getClusterName()).size();
-        new DoubleRing(cassandraConfiguration, amazonConfiguration, instanceRegistry, tokenManager).doubleSlots();
-        List<PriamInstance> doubled = instanceRegistry.getAllIds(cassandraConfiguration.getClusterName());
-        doubled = Ordering.natural().immutableSortedCopy(doubled);
+        Multimap<Location, PriamInstance> originalInstances = getInstancesByLocation();
+        // Should have been three distinct rings in the cluster
+        assertEquals(3, originalInstances.keySet().size());
+        int originalSize = originalInstances.get(location).size();
+        assertEquals(9, originalSize);
 
+        new DoubleRing(cassandraConfiguration, amazonConfiguration, instanceRegistry, tokenManager, location).doubleSlots();
+        Multimap<Location, PriamInstance> doubledInstances = getInstancesByLocation();
+
+        List<PriamInstance> doubled = Ordering.natural().immutableSortedCopy(doubledInstances.get(location));
         assertEquals(originalSize * 2, doubled.size());
         validate(doubled);
+
+        // Verify instances in remote locations are unchanged
+        for (Location remoteLocation : originalInstances.keySet()) {
+            if (!location.equals(remoteLocation)) {
+                assertEquals(originalInstances.get(remoteLocation), doubledInstances.get(remoteLocation));
+            }
+        }
     }
 
     private void validate(List<PriamInstance> doubled) {
         List<String> validator = Lists.newArrayList();
         for (int i = 0; i < doubled.size(); i++) {
-            validator.add(tokenManager.createToken(i, doubled.size(), amazonConfiguration.getRegionName()));
+            validator.add(tokenManager.createToken(i, doubled.size(), location));
 
         }
 
@@ -35,7 +52,7 @@ public class DoubleRingTest extends InstanceTestUtils {
         for (int i = 0; i < doubled.size(); i++) {
             PriamInstance ins = doubled.get(i);
             assertEquals(validator.get(i), ins.getToken());
-            int id = ins.getId() - TokenManager.regionOffset(amazonConfiguration.getRegionName());
+            int id = ins.getId() - TokenManager.locationOffset(location);
             //System.out.println(ins);
             if (0 != id % 2) {
                 assertEquals(ins.getInstanceId(), PriamInstance.NEW_INSTANCE_PLACEHOLDER_ID);
@@ -48,12 +65,25 @@ public class DoubleRingTest extends InstanceTestUtils {
     @Test
     public void testBR() throws Exception {
         createInstances();
-        int intialSize = instanceRegistry.getAllIds(cassandraConfiguration.getClusterName()).size();
-        DoubleRing ring = new DoubleRing(cassandraConfiguration, amazonConfiguration, instanceRegistry, tokenManager);
+        Multimap<Location, PriamInstance> originalInstances = getInstancesByLocation();
+        int initialClusterSize = originalInstances.size();
+        int initialRingSize = originalInstances.get(location).size();
+        DoubleRing ring = new DoubleRing(cassandraConfiguration, amazonConfiguration, instanceRegistry, tokenManager, location);
         ring.backup();
         ring.doubleSlots();
-        assertEquals(intialSize * 2, instanceRegistry.getAllIds(cassandraConfiguration.getClusterName()).size());
+        // Only the local ring will have doubled; remote rings will be unchanged
+        assertEquals(initialClusterSize + initialRingSize, instanceRegistry.getAllIds(cassandraConfiguration.getClusterName()).size());
         ring.restore();
-        assertEquals(intialSize, instanceRegistry.getAllIds(cassandraConfiguration.getClusterName()).size());
+        assertEquals(initialClusterSize, instanceRegistry.getAllIds(cassandraConfiguration.getClusterName()).size());
+    }
+
+    private Multimap<Location, PriamInstance> getInstancesByLocation() {
+        return Multimaps.index(instanceRegistry.getAllIds(cassandraConfiguration.getClusterName()), new Function<PriamInstance, Location>() {
+            @Nullable
+            @Override
+            public Location apply(PriamInstance instance) {
+                return instance.getLocation();
+            }
+        });
     }
 }

--- a/priam/src/test/java/com/netflix/priam/identity/InstanceIdentityTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/InstanceIdentityTest.java
@@ -2,18 +2,15 @@ package com.netflix.priam.identity;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import com.netflix.priam.utils.ThreadSleeper;
+import com.google.common.collect.Sets;
 import com.netflix.priam.utils.TokenManager;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class InstanceIdentityTest extends InstanceTestUtils {
@@ -22,7 +19,7 @@ public class InstanceIdentityTest extends InstanceTestUtils {
     public void testCreateToken() throws Exception {
 
         identity = createInstanceIdentity("az1", "fakeinstance1");
-        int hash = TokenManager.regionOffset(amazonConfiguration.getRegionName());
+        int hash = TokenManager.locationOffset(location);
         assertEquals(0, identity.getInstance().getId() - hash);
 
         identity = createInstanceIdentity("az1", "fakeinstance2");
@@ -57,7 +54,7 @@ public class InstanceIdentityTest extends InstanceTestUtils {
         createInstances();
         instances.remove("fakeinstance4");
         identity = createInstanceIdentity("az2", "fakeinstancex");
-        int hash = TokenManager.regionOffset(amazonConfiguration.getRegionName());
+        int hash = TokenManager.locationOffset(location);
         assertEquals(1, identity.getInstance().getId() - hash);
 
         // Ensure that we are flagged as replacing the proper instance
@@ -69,20 +66,39 @@ public class InstanceIdentityTest extends InstanceTestUtils {
     public void testGetSeeds() throws Exception {
         createInstances();
         identity = createInstanceIdentity("az1", "fakeinstancex");
-        assertEquals(2, identity.getSeeds().size());
+        // There should be 8 seeds; 2 local + 6 remote (3 each from 2 other data centers)
+        assertEquals(8, identity.getSeeds().size());
         assertFalse(identity.isReplace());
 
         identity = createInstanceIdentity("az1", "fakeinstance1");
-        assertEquals(2, identity.getSeeds().size());
+        assertEquals(8, identity.getSeeds().size());
         assertFalse(identity.isReplace());
     }
 
     @Test
     public void testDoubleSlots() throws Exception {
         createInstances();
-        int before = instanceRegistry.getAllIds("fake-app").size();
-        new DoubleRing(cassandraConfiguration, amazonConfiguration, instanceRegistry, tokenManager).doubleSlots();
-        List<PriamInstance> lst = instanceRegistry.getAllIds(cassandraConfiguration.getClusterName());
+        Set<PriamInstance> remoteInstances = Sets.newLinkedHashSet();
+        int before = 0;
+        for (PriamInstance instance : instanceRegistry.getAllIds("fake-app")) {
+            if (instance.getLocation().equals(location)) {
+                before += 1;
+            } else {
+                remoteInstances.add(instance);
+            }
+        }
+
+        new DoubleRing(cassandraConfiguration, amazonConfiguration, instanceRegistry, tokenManager, location).doubleSlots();
+        List<PriamInstance> lst = Lists.newArrayList();
+        Set<PriamInstance> afterRemoteInstances = Sets.newLinkedHashSet();
+        // Only look at local instances
+        for (PriamInstance instance : instanceRegistry.getAllIds(cassandraConfiguration.getClusterName())) {
+            if (instance.getLocation().equals(location)) {
+                lst.add(instance);
+            } else {
+                afterRemoteInstances.add(instance);
+            }
+        }
         // sort it so it will look good if you want to print it.
         lst = Ordering.natural().immutableSortedCopy(lst);
         for (int i = 0; i < lst.size(); i++) {
@@ -93,15 +109,17 @@ public class InstanceIdentityTest extends InstanceTestUtils {
             assertEquals(PriamInstance.NEW_INSTANCE_PLACEHOLDER_ID, lst.get(i).getInstanceId());
         }
         assertEquals(before * 2, lst.size());
+        // Remote instances should be unchanged after doubling locally
+        assertEquals(remoteInstances, afterRemoteInstances);
     }
 
     @Test
     public void testDoubleGrap() throws Exception {
         createInstances();
-        new DoubleRing(cassandraConfiguration, amazonConfiguration, instanceRegistry, tokenManager).doubleSlots();
+        new DoubleRing(cassandraConfiguration, amazonConfiguration, instanceRegistry, tokenManager, location).doubleSlots();
         amazonConfiguration.setAvailabilityZone("az1");
         amazonConfiguration.setInstanceID("fakeinstancex");
-        int hash = TokenManager.regionOffset(amazonConfiguration.getRegionName());
+        int hash = TokenManager.locationOffset(location);
         identity = createInstanceIdentity("az1", "fakeinstancex");
         printInstance(identity.getInstance(), hash);
 

--- a/priam/src/test/java/com/netflix/priam/identity/LocationTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/LocationTest.java
@@ -1,0 +1,20 @@
+package com.netflix.priam.identity;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LocationTest {
+
+    @Test
+    public void testLocationSerialization() {
+        Location expectedNoSuffix = new SimpleLocation("fake-region", "");
+        Location expectedWithSuffix = new SimpleLocation("fake-region", "sfx");
+
+        assertEquals("fake-region", expectedNoSuffix.toString());
+        assertEquals("fake-region/sfx", expectedWithSuffix.toString());
+
+        assertEquals(Location.from("fake-region"), expectedNoSuffix);
+        assertEquals(Location.from("fake-region/sfx"), expectedWithSuffix);
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/utils/BOPTokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/BOPTokenManagerTest.java
@@ -2,6 +2,7 @@ package com.netflix.priam.utils;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.netflix.priam.identity.Location;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.BytesToken;
 import org.apache.cassandra.dht.Token;
@@ -81,9 +82,9 @@ public class BOPTokenManagerTest {
                         .add(BigInteger.ONE)
                         .divide(BigInteger.valueOf(8 * 32))
                         .multiply(BigInteger.TEN)
-                        .add(BigInteger.valueOf(TokenManager.regionOffset("region")))
+                        .add(BigInteger.valueOf(TokenManager.locationOffset(Location.from("region"))))
                         .toString(16), 32, '0'),
-                tokenManager.createToken(10, 8, 32, "region"));
+                tokenManager.createToken(10, 8, 32, Location.from("region")));
     }
 
     @Test
@@ -91,19 +92,21 @@ public class BOPTokenManagerTest {
         // 6 node clusters should have 6 tokens distributed evenly from 0 to 2^128 (exclusive) + region offset
         BOPTokenManager tokenManager = newBOPTokenManager(16);
 
-        assertEquals("0000000000000000000000006bccac70", tokenManager.createToken(0, 3, 2, "us-east-1"));
-        assertEquals("2aaaaaaaaaaaaaaaaaaaaaab1677571a", tokenManager.createToken(1, 3, 2, "us-east-1"));
-        assertEquals("555555555555555555555555c12201c4", tokenManager.createToken(2, 3, 2, "us-east-1"));
-        assertEquals("8000000000000000000000006bccac6e", tokenManager.createToken(3, 3, 2, "us-east-1"));
-        assertEquals("aaaaaaaaaaaaaaaaaaaaaaab16775718", tokenManager.createToken(4, 3, 2, "us-east-1"));
-        assertEquals("d55555555555555555555555c12201c2", tokenManager.createToken(5, 3, 2, "us-east-1"));
+        Location usEast1 = Location.from("us-east-1");
+        assertEquals("0000000000000000000000006bccac70", tokenManager.createToken(0, 3, 2, usEast1));
+        assertEquals("2aaaaaaaaaaaaaaaaaaaaaab1677571a", tokenManager.createToken(1, 3, 2, usEast1));
+        assertEquals("555555555555555555555555c12201c4", tokenManager.createToken(2, 3, 2, usEast1));
+        assertEquals("8000000000000000000000006bccac6e", tokenManager.createToken(3, 3, 2, usEast1));
+        assertEquals("aaaaaaaaaaaaaaaaaaaaaaab16775718", tokenManager.createToken(4, 3, 2, usEast1));
+        assertEquals("d55555555555555555555555c12201c2", tokenManager.createToken(5, 3, 2, usEast1));
 
-        assertEquals("0000000000000000000000001637af50", tokenManager.createToken(0, 3, 2, "eu-west-1"));
-        assertEquals("2aaaaaaaaaaaaaaaaaaaaaaac0e259fa", tokenManager.createToken(1, 3, 2, "eu-west-1"));
-        assertEquals("5555555555555555555555556b8d04a4", tokenManager.createToken(2, 3, 2, "eu-west-1"));
-        assertEquals("8000000000000000000000001637af4e", tokenManager.createToken(3, 3, 2, "eu-west-1"));
-        assertEquals("aaaaaaaaaaaaaaaaaaaaaaaac0e259f8", tokenManager.createToken(4, 3, 2, "eu-west-1"));
-        assertEquals("d555555555555555555555556b8d04a2", tokenManager.createToken(5, 3, 2, "eu-west-1"));
+        Location euWest1 = Location.from("eu-west-1");
+        assertEquals("0000000000000000000000001637af50", tokenManager.createToken(0, 3, 2, euWest1));
+        assertEquals("2aaaaaaaaaaaaaaaaaaaaaaac0e259fa", tokenManager.createToken(1, 3, 2, euWest1));
+        assertEquals("5555555555555555555555556b8d04a4", tokenManager.createToken(2, 3, 2, euWest1));
+        assertEquals("8000000000000000000000001637af4e", tokenManager.createToken(3, 3, 2, euWest1));
+        assertEquals("aaaaaaaaaaaaaaaaaaaaaaaac0e259f8", tokenManager.createToken(4, 3, 2, euWest1));
+        assertEquals("d555555555555555555555556b8d04a2", tokenManager.createToken(5, 3, 2, euWest1));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -198,7 +201,7 @@ public class BOPTokenManagerTest {
                     continue;
                 }
                 assertFalse("Difference seems to be low",
-                        Math.abs(TokenManager.regionOffset(region1) - TokenManager.regionOffset(region2)) < 100);
+                        Math.abs(TokenManager.locationOffset(Location.from(region1)) - TokenManager.locationOffset(Location.from(region2))) < 100);
             }
         }
     }
@@ -207,8 +210,8 @@ public class BOPTokenManagerTest {
     public void testMultiToken() {
         BOPTokenManager tokenManager = new BOPTokenManager(8, "0000000000000000", "ffffffffffffffff");
 
-        int h1 = TokenManager.regionOffset("vijay");
-        int h2 = TokenManager.regionOffset("vijay2");
+        int h1 = TokenManager.locationOffset(Location.from("vijay"));
+        int h2 = TokenManager.locationOffset(Location.from("vijay2"));
         Token t1 = tokenManager.initialToken(100, 10, h1);
         Token t2 = tokenManager.initialToken(100, 10, h2);
 
@@ -250,14 +253,14 @@ public class BOPTokenManagerTest {
         BOPTokenManager tokenManager1 = new BOPTokenManager(18,
                 "555500112233445566778899aabbccddeeff",
                 "5555ffeeddccbbaa99887766554433221100");
-        assertEquals("55552ab616ccd838eefa5b111c7d49764ea4", tokenManager1.createToken(1, 3, 2, "eu-west-1"));
+        assertEquals("55552ab616ccd838eefa5b111c7d49764ea4", tokenManager1.createToken(1, 3, 2, Location.from("eu-west-1")));
 
         // Next, test with much longer min/max values.
         BOPTokenManager tokenManager2 = new BOPTokenManager(50,
                 "555500112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
                 "5555ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100");
         assertEquals("55552ab616ccd838eefa5b111c7d333e9f54aab616ccd838eefa5b111c7d333e9f54aab616ccd838eefa5b111c7d49764ea4",
-                tokenManager2.createToken(1, 3, 2, "eu-west-1"));
+                tokenManager2.createToken(1, 3, 2, Location.from("eu-west-1")));
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/utils/BOPTokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/BOPTokenManagerTest.java
@@ -3,6 +3,7 @@ package com.netflix.priam.utils;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.netflix.priam.identity.Location;
+import com.netflix.priam.identity.SimpleLocation;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.BytesToken;
 import org.apache.cassandra.dht.Token;
@@ -192,16 +193,23 @@ public class BOPTokenManagerTest {
     }
 
     @Test
-    public void regionOffset() {
+    public void testLocationOffset() {
         String allRegions = "us-west-2,us-east,us-west,eu-east,eu-west,ap-northeast,ap-southeast";
+        String dcSuffixes = ",-dev,-qa,-prod";
 
         for (String region1 : allRegions.split(",")) {
             for (String region2 : allRegions.split(",")) {
-                if (region1.equals(region2)) {
-                    continue;
+                for (String dcSuffix1 : dcSuffixes.split(",")) {
+                    for (String dcSuffix2: dcSuffixes.split(",")) {
+                        if (region1.equals(region2) && dcSuffix1.equals(dcSuffix2)) {
+                            continue;
+                        }
+                        Location loc1 = new SimpleLocation(region1, dcSuffix1);
+                        Location loc2 = new SimpleLocation(region2, dcSuffix2);
+                        assertFalse("Difference seems to be low",
+                                Math.abs(TokenManager.locationOffset(loc1) - TokenManager.locationOffset(loc2)) < 100);
+                    }
                 }
-                assertFalse("Difference seems to be low",
-                        Math.abs(TokenManager.locationOffset(Location.from(region1)) - TokenManager.locationOffset(Location.from(region2))) < 100);
             }
         }
     }

--- a/priam/src/test/java/com/netflix/priam/utils/Murmur3PartitionerTokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/Murmur3PartitionerTokenManagerTest.java
@@ -2,6 +2,7 @@ package com.netflix.priam.utils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
+import com.netflix.priam.identity.Location;
 import org.apache.cassandra.dht.BigIntegerToken;
 import org.apache.cassandra.dht.RandomPartitioner;
 import org.junit.Test;
@@ -66,28 +67,30 @@ public class Murmur3PartitionerTokenManagerTest {
                         .subtract(MINIMUM_TOKEN)
                         .divide(BigInteger.valueOf(8 * 32))
                         .multiply(BigInteger.TEN)
-                        .add(BigInteger.valueOf(TokenManager.regionOffset("region")))
+                        .add(BigInteger.valueOf(TokenManager.locationOffset(Location.from("region"))))
                         .add(MINIMUM_TOKEN)
                         .toString(),
-                tokenManager.createToken(10, 8, 32, "region"));
+                tokenManager.createToken(10, 8, 32, Location.from("region")));
     }
 
     @Test
     public void createToken_typical() {
         // 6 node clusters should have 6 tokens distributed evenly from -2^63 to 2^63 (exclusive) + region offset
-        assertEquals("-9223372035046200208", tokenManager.createToken(0, 3, 2, "us-east-1"));
-        assertEquals("-6148914689427941606", tokenManager.createToken(1, 3, 2, "us-east-1"));
-        assertEquals("-3074457343809683004", tokenManager.createToken(2, 3, 2, "us-east-1"));
-        assertEquals("1808575598", tokenManager.createToken(3, 3, 2, "us-east-1"));
-        assertEquals("3074457347426834200", tokenManager.createToken(4, 3, 2, "us-east-1"));
-        assertEquals("6148914693045092802", tokenManager.createToken(5, 3, 2, "us-east-1"));
+        Location usEast1 = Location.from("us-east-1");
+        assertEquals("-9223372035046200208", tokenManager.createToken(0, 3, 2, usEast1));
+        assertEquals("-6148914689427941606", tokenManager.createToken(1, 3, 2, usEast1));
+        assertEquals("-3074457343809683004", tokenManager.createToken(2, 3, 2, usEast1));
+        assertEquals("1808575598", tokenManager.createToken(3, 3, 2, usEast1));
+        assertEquals("3074457347426834200", tokenManager.createToken(4, 3, 2, usEast1));
+        assertEquals("6148914693045092802", tokenManager.createToken(5, 3, 2, usEast1));
 
-        assertEquals("-9223372036482027696", tokenManager.createToken(0, 3, 2, "eu-west-1"));
-        assertEquals("-6148914690863769094", tokenManager.createToken(1, 3, 2, "eu-west-1"));
-        assertEquals("-3074457345245510492", tokenManager.createToken(2, 3, 2, "eu-west-1"));
-        assertEquals("372748110", tokenManager.createToken(3, 3, 2, "eu-west-1"));
-        assertEquals("3074457345991006712", tokenManager.createToken(4, 3, 2, "eu-west-1"));
-        assertEquals("6148914691609265314", tokenManager.createToken(5, 3, 2, "eu-west-1"));
+        Location euWest1 = Location.from("eu-west-1");
+        assertEquals("-9223372036482027696", tokenManager.createToken(0, 3, 2, euWest1));
+        assertEquals("-6148914690863769094", tokenManager.createToken(1, 3, 2, euWest1));
+        assertEquals("-3074457345245510492", tokenManager.createToken(2, 3, 2, euWest1));
+        assertEquals("372748110", tokenManager.createToken(3, 3, 2, euWest1));
+        assertEquals("3074457345991006712", tokenManager.createToken(4, 3, 2, euWest1));
+        assertEquals("6148914691609265314", tokenManager.createToken(5, 3, 2, euWest1));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -151,15 +154,15 @@ public class Murmur3PartitionerTokenManagerTest {
                     continue;
                 }
                 assertFalse("Difference seems to be low",
-                        Math.abs(TokenManager.regionOffset(region1) - TokenManager.regionOffset(region2)) < 100);
+                        Math.abs(TokenManager.locationOffset(Location.from(region1)) - TokenManager.locationOffset(Location.from(region2))) < 100);
             }
         }
     }
 
     @Test
     public void testMultiToken() {
-        int h1 = TokenManager.regionOffset("vijay");
-        int h2 = TokenManager.regionOffset("vijay2");
+        int h1 = TokenManager.locationOffset(Location.from("vijay"));
+        int h2 = TokenManager.locationOffset(Location.from("vijay2"));
         BigInteger t1 = tokenManager.initialToken(100, 10, h1);
         BigInteger t2 = tokenManager.initialToken(100, 10, h2);
 

--- a/priam/src/test/java/com/netflix/priam/utils/Murmur3PartitionerTokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/Murmur3PartitionerTokenManagerTest.java
@@ -3,6 +3,7 @@ package com.netflix.priam.utils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import com.netflix.priam.identity.Location;
+import com.netflix.priam.identity.SimpleLocation;
 import org.apache.cassandra.dht.BigIntegerToken;
 import org.apache.cassandra.dht.RandomPartitioner;
 import org.junit.Test;
@@ -145,16 +146,23 @@ public class Murmur3PartitionerTokenManagerTest {
     }
 
     @Test
-    public void regionOffset() {
+    public void testLocationOffset() {
         String allRegions = "us-west-2,us-east,us-west,eu-east,eu-west,ap-northeast,ap-southeast";
+        String dcSuffixes = ",-dev,-qa,-prod";
 
         for (String region1 : allRegions.split(",")) {
             for (String region2 : allRegions.split(",")) {
-                if (region1.equals(region2)) {
-                    continue;
+                for (String dcSuffix1 : dcSuffixes.split(",")) {
+                    for (String dcSuffix2: dcSuffixes.split(",")) {
+                        if (region1.equals(region2) && dcSuffix1.equals(dcSuffix2)) {
+                            continue;
+                        }
+                        Location loc1 = new SimpleLocation(region1, dcSuffix1);
+                        Location loc2 = new SimpleLocation(region2, dcSuffix2);
+                        assertFalse("Difference seems to be low",
+                                Math.abs(TokenManager.locationOffset(loc1) - TokenManager.locationOffset(loc2)) < 100);
+                    }
                 }
-                assertFalse("Difference seems to be low",
-                        Math.abs(TokenManager.locationOffset(Location.from(region1)) - TokenManager.locationOffset(Location.from(region2))) < 100);
             }
         }
     }

--- a/priam/src/test/java/com/netflix/priam/utils/RandomPartitionerTokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/RandomPartitionerTokenManagerTest.java
@@ -2,6 +2,7 @@ package com.netflix.priam.utils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
+import com.netflix.priam.identity.Location;
 import org.apache.cassandra.dht.BigIntegerToken;
 import org.apache.cassandra.dht.RandomPartitioner;
 import org.junit.Test;
@@ -63,9 +64,9 @@ public class RandomPartitionerTokenManagerTest {
     public void createToken() {
         assertEquals(MAXIMUM_TOKEN.divide(BigInteger.valueOf(8 * 32))
                         .multiply(BigInteger.TEN)
-                        .add(BigInteger.valueOf(TokenManager.regionOffset("region")))
+                        .add(BigInteger.valueOf(TokenManager.locationOffset(Location.from("region"))))
                         .toString(),
-                tokenManager.createToken(10, 8, 32, "region"));
+                tokenManager.createToken(10, 8, 32, Location.from("region")));
     }
 
     /*
@@ -73,19 +74,21 @@ public class RandomPartitionerTokenManagerTest {
     @Test
     public void createToken_typical() {
         // 6 node clusters should have 6 tokens distributed evenly from 0 to 2^127 (exclusive) + region offset
-        assertEquals("1808575600", tokenManager.createToken(0, 3, 2, "us-east-1"));
-        assertEquals("28356863910078205288614550621122593221", tokenManager.createToken(1, 3, 2, "us-east-1"));
-        assertEquals("56713727820156410577229101240436610842", tokenManager.createToken(2, 3, 2, "us-east-1"));
-        assertEquals("85070591730234615865843651859750628463", tokenManager.createToken(3, 3, 2, "us-east-1"));
-        assertEquals("113427455640312821154458202479064646084", tokenManager.createToken(4, 3, 2, "us-east-1"));
-        assertEquals("141784319550391026443072753098378663705", tokenManager.createToken(5, 3, 2, "us-east-1"));
+        Location usEast1 = Location.from("us-east-1");
+        assertEquals("1808575600", tokenManager.createToken(0, 3, 2, usEast1));
+        assertEquals("28356863910078205288614550621122593221", tokenManager.createToken(1, 3, 2, usEast1));
+        assertEquals("56713727820156410577229101240436610842", tokenManager.createToken(2, 3, 2, usEast1));
+        assertEquals("85070591730234615865843651859750628463", tokenManager.createToken(3, 3, 2, usEast1));
+        assertEquals("113427455640312821154458202479064646084", tokenManager.createToken(4, 3, 2, usEast1));
+        assertEquals("141784319550391026443072753098378663705", tokenManager.createToken(5, 3, 2, usEast1));
 
-        assertEquals("372748112", tokenManager.createToken(0, 3, 2, "eu-west-1"));
-        assertEquals("28356863910078205288614550619686765733", tokenManager.createToken(1, 3, 2, "eu-west-1"));
-        assertEquals("56713727820156410577229101239000783354", tokenManager.createToken(2, 3, 2, "eu-west-1"));
-        assertEquals("85070591730234615865843651858314800975", tokenManager.createToken(3, 3, 2, "eu-west-1"));
-        assertEquals("113427455640312821154458202477628818596", tokenManager.createToken(4, 3, 2, "eu-west-1"));
-        assertEquals("141784319550391026443072753096942836217", tokenManager.createToken(5, 3, 2, "eu-west-1"));
+        Location euWest1 = Location.from("eu-west-1");
+        assertEquals("372748112", tokenManager.createToken(0, 3, 2, euWest1));
+        assertEquals("28356863910078205288614550619686765733", tokenManager.createToken(1, 3, 2, euWest1));
+        assertEquals("56713727820156410577229101239000783354", tokenManager.createToken(2, 3, 2, euWest1));
+        assertEquals("85070591730234615865843651858314800975", tokenManager.createToken(3, 3, 2, euWest1));
+        assertEquals("113427455640312821154458202477628818596", tokenManager.createToken(4, 3, 2, euWest1));
+        assertEquals("141784319550391026443072753096942836217", tokenManager.createToken(5, 3, 2, euWest1));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -154,15 +157,15 @@ public class RandomPartitionerTokenManagerTest {
                     continue;
                 }
                 assertFalse("Difference seems to be low",
-                        Math.abs(TokenManager.regionOffset(region1) - TokenManager.regionOffset(region2)) < 100);
+                        Math.abs(TokenManager.locationOffset(Location.from(region1)) - TokenManager.locationOffset(Location.from(region2))) < 100);
             }
         }
     }
 
     @Test
     public void testMultiToken() {
-        int h1 = TokenManager.regionOffset("vijay");
-        int h2 = TokenManager.regionOffset("vijay2");
+        int h1 = TokenManager.locationOffset(Location.from("vijay"));
+        int h2 = TokenManager.locationOffset(Location.from("vijay2"));
         BigInteger t1 = tokenManager.initialToken(100, 10, h1);
         BigInteger t2 = tokenManager.initialToken(100, 10, h2);
 

--- a/priam/src/test/java/com/netflix/priam/utils/RandomPartitionerTokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/RandomPartitionerTokenManagerTest.java
@@ -3,6 +3,7 @@ package com.netflix.priam.utils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import com.netflix.priam.identity.Location;
+import com.netflix.priam.identity.SimpleLocation;
 import org.apache.cassandra.dht.BigIntegerToken;
 import org.apache.cassandra.dht.RandomPartitioner;
 import org.junit.Test;
@@ -148,16 +149,23 @@ public class RandomPartitionerTokenManagerTest {
     }
 
     @Test
-    public void regionOffset() {
+    public void testLocationOffset() {
         String allRegions = "us-west-2,us-east,us-west,eu-east,eu-west,ap-northeast,ap-southeast";
+        String dcSuffixes = ",-dev,-qa,-prod";
 
         for (String region1 : allRegions.split(",")) {
             for (String region2 : allRegions.split(",")) {
-                if (region1.equals(region2)) {
-                    continue;
+                for (String dcSuffix1 : dcSuffixes.split(",")) {
+                    for (String dcSuffix2: dcSuffixes.split(",")) {
+                        if (region1.equals(region2) && dcSuffix1.equals(dcSuffix2)) {
+                            continue;
+                        }
+                        Location loc1 = new SimpleLocation(region1, dcSuffix1);
+                        Location loc2 = new SimpleLocation(region2, dcSuffix2);
+                        assertFalse("Difference seems to be low",
+                                Math.abs(TokenManager.locationOffset(loc1) - TokenManager.locationOffset(loc2)) < 100);
+                    }
                 }
-                assertFalse("Difference seems to be low",
-                        Math.abs(TokenManager.locationOffset(Location.from(region1)) - TokenManager.locationOffset(Location.from(region2))) < 100);
             }
         }
     }


### PR DESCRIPTION
Prior to this PR Priam computed the data center based solely on the AWS region name.  For example, all instances in the cluster from "us-east-1" would be placed in data center "us-east".  This PR adds a new object, `Location`, which is the tuple of AWS region name and data center suffix.  The data center suffix is an existing part of Cassandra and the `Ec2Snitch` which adds a suffix to the data center name to effectively make it a different ring in the same data center.  Data center suffix is provided via the Priam `config.yaml`.  The parts of Priam which relied only on AWS region name, such as for ring determination and token offset calculation, have been updated to use `Location` instead.

Our practical application for this is to allow two rings in the same cluster in the bv-nexus and bv-nexus-qa or bv-nexus-prod accounts.  This will enable a smoother transition from one VPC to the other without doubling the existing ring or re-allocating tokens.  Keyspaces can be replicated to the new ring and, once complete, the old ring can be removed.