### PR TITLE
Fixed assume role sessions to always be less than 64 characters

### DIFF
--- a/priam/src/main/java/com/netflix/priam/dropwizard/PriamService.java
+++ b/priam/src/main/java/com/netflix/priam/dropwizard/PriamService.java
@@ -49,8 +49,6 @@ public class PriamService extends Application<PriamConfiguration> {
 
         Injector injector = Guice.createInjector(new PriamGuiceModule(config, environment));
         try {
-            config.getAmazonConfiguration().discoverConfiguration(injector.getInstance(AWSCredentialsProvider.class));
-
             environment.lifecycle().manage(injector.getInstance(PriamServer.class));
             environment.lifecycle().manage(injector.getInstance(ServiceRegistryManager.class));
             environment.lifecycle().manage(injector.getInstance(ServiceMonitorManager.class));


### PR DESCRIPTION
This fixes an issue where the STS assume role session name can be at most 64 characters.  With our default stack names this was too long and causing Priam to fail.  The change is to use the instance IP to make the session name unique instead of a long semi-random string.