### PR TITLE
EMO-6444: Support EmoPartitioner

### DIFF
--- a/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import com.netflix.priam.config.BackupConfiguration;
 import com.netflix.priam.config.CassandraConfiguration;
 import com.netflix.priam.utils.CassandraTuner;
+import com.netflix.priam.utils.TokenManager;
 import org.apache.cassandra.locator.SnitchProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,6 +141,13 @@ public class StandardTuner implements CassandraTuner {
         if (lowerCase.contains("randomparti") || lowerCase.contains("murmur")) {
             return fromConfig;
         }
+        
+        // If both partitioners are either ByteOrderedPartitioner or EmoPartitioner than accept whichever
+        // is from the configuration file.
+        if (TokenManager.clientPartitioner(fromYaml).equals(TokenManager.clientPartitioner(fromConfig))) {
+            return fromConfig;
+        }
+
         return fromYaml;
     }
 

--- a/priam/src/main/java/com/netflix/priam/dropwizard/managers/ServiceRegistryManager.java
+++ b/priam/src/main/java/com/netflix/priam/dropwizard/managers/ServiceRegistryManager.java
@@ -18,6 +18,7 @@ import com.netflix.priam.config.AmazonConfiguration;
 import com.netflix.priam.config.CassandraConfiguration;
 import com.netflix.priam.config.PriamConfiguration;
 import com.netflix.priam.utils.JMXNodeTool;
+import com.netflix.priam.utils.TokenManager;
 import io.dropwizard.lifecycle.Managed;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.curator.framework.CuratorFramework;
@@ -87,7 +88,7 @@ public class ServiceRegistryManager implements Managed {
         // Include the partitioner in the Ostrich end point data to support clients that need to know the
         // partitioner type before they connect to the ring (eg. Astyanax).
         Map<String, Object> payload = ImmutableMap.<String, Object>of(
-                "partitioner", FBUtilities.newPartitioner(casConfiguration.getPartitioner()).getClass().getName(),
+                "partitioner", FBUtilities.newPartitioner(TokenManager.clientPartitioner(casConfiguration.getPartitioner())).getClass().getName(),
                 "url", priamServiceBaseURL);
         String payloadString = new ObjectMapper().writeValueAsString(payload);
 

--- a/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
+++ b/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
@@ -50,13 +50,16 @@ public abstract class TokenManager {
     }
 
     /**
-     * From a client perspective EmoPartitioner and ByteOrderedPartitioner are effectively the same: both produce
-     * the same tokens, splits, and so on.  Rather than force all clients which require a partitioner to duplicate
-     * the ByteOrderedPartitioner implementation when EmoPartitioner is configured this method replaces EmoPartitioner
-     * with ByteOrderedPartitioner as the effective partitioner for client access.
+     * From a client perspective an Emo partitioner implementation and ByteOrderedPartitioner are effectively the same:
+     * both produce the same tokens, splits, and so on.  Rather than force all clients which require a partitioner to
+     * duplicate the ByteOrderedPartitioner implementation when an Emo partitioner is configured this method replaces
+     * the partitioner with ByteOrderedPartitioner.
+     *
+     * Rather than checking for any particular class this method simply looks for the substring "emo" within the
+     * partitioner name and, if found, presumes it is a BOP-compatible partitioner.
      */
     public static String clientPartitioner(String partitioner) {
-        if ("com.bazaarvoice.emodb.partitioner.EmoPartitioner".equals(partitioner)) {
+        if (partitioner.toLowerCase().contains("emo")) {
             return ByteOrderedPartitioner.class.getName();
         }
         return partitioner;

--- a/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
+++ b/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
@@ -16,6 +16,7 @@
 package com.netflix.priam.utils;
 
 import com.netflix.priam.identity.Location;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
 
 import java.util.List;
 
@@ -46,5 +47,18 @@ public abstract class TokenManager {
      */
     public static int locationOffset(Location location) {
         return Math.abs(location.hashCode());
+    }
+
+    /**
+     * From a client perspective EmoPartitioner and ByteOrderedPartitioner are effectively the same: both produce
+     * the same tokens, splits, and so on.  Rather than force all clients which require a partitioner to duplicate
+     * the ByteOrderedPartitioner implementation when EmoPartitioner is configured this method replaces EmoPartitioner
+     * with ByteOrderedPartitioner as the effective partitioner for client access.
+     */
+    public static String clientPartitioner(String partitioner) {
+        if ("com.bazaarvoice.emodb.partitioner.EmoPartitioner".equals(partitioner)) {
+            return ByteOrderedPartitioner.class.getName();
+        }
+        return partitioner;
     }
 }

--- a/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
+++ b/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
@@ -50,16 +50,13 @@ public abstract class TokenManager {
     }
 
     /**
-     * From a client perspective an Emo partitioner implementation and ByteOrderedPartitioner are effectively the same:
-     * both produce the same tokens, splits, and so on.  Rather than force all clients which require a partitioner to
-     * duplicate the ByteOrderedPartitioner implementation when an Emo partitioner is configured this method replaces
-     * the partitioner with ByteOrderedPartitioner.
-     *
-     * Rather than checking for any particular class this method simply looks for the substring "emo" within the
-     * partitioner name and, if found, presumes it is a BOP-compatible partitioner.
+     * From a client perspective EmoPartitioner and ByteOrderedPartitioner are effectively the same: both produce
+     * the same tokens, splits, and so on.  Rather than force all clients which require a partitioner to duplicate
+     * the ByteOrderedPartitioner implementation when EmoPartitioner is configured this method replaces EmoPartitioner
+     * with ByteOrderedPartitioner as the effective partitioner for client access.
      */
     public static String clientPartitioner(String partitioner) {
-        if (partitioner.toLowerCase().contains("emo")) {
+        if ("com.bazaarvoice.emodb.partitioner.EmoPartitioner".equals(partitioner)) {
             return ByteOrderedPartitioner.class.getName();
         }
         return partitioner;

--- a/priam/src/main/java/com/netflix/priam/utils/TokenManagerProvider.java
+++ b/priam/src/main/java/com/netflix/priam/utils/TokenManagerProvider.java
@@ -26,7 +26,7 @@ public class TokenManagerProvider implements Provider<TokenManager> {
     public TokenManager get() {
         IPartitioner partitioner;
         try {
-            partitioner = FBUtilities.newPartitioner(_cassandraConfiguration.getPartitioner());
+            partitioner = FBUtilities.newPartitioner(TokenManager.clientPartitioner(_cassandraConfiguration.getPartitioner()));
         } catch (ConfigurationException e) {
             throw Throwables.propagate(e);
         }


### PR DESCRIPTION
This update allows configuring EmoPartitioner as the Cassandra partitioner while still publicly representing the partitioner as ByteOrderedPartitioner.  This is to avoid the need for Priam or Astyanax in Emo to require an additional redundant EmoPartitioner implementation.