### PR TITLE
EMO-6457 EMO-6476: Added volume metadata for detecting re-attached EBS volumes

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/AmazonConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/AmazonConfiguration.java
@@ -55,6 +55,9 @@ public class AmazonConfiguration {
     @JsonProperty
     private String simpleDbRegion;   // Defaults to the current region.  Set explicitly for cross-dc rings.
 
+    @JsonProperty
+    private String cassandraVolumeBlockDevice;
+
     public String getAutoScaleGroupName() {
         return autoScaleGroupName;
     }
@@ -103,6 +106,10 @@ public class AmazonConfiguration {
         return StringUtils.isNotBlank(simpleDbRegion) ? simpleDbRegion : "us-east-1";
     }
 
+    public String getCassandraVolumeBlockDevice() {
+        return cassandraVolumeBlockDevice;
+    }
+
     public void setAutoScaleGroupName(String autoScaleGroupName) {
         this.autoScaleGroupName = autoScaleGroupName;
     }
@@ -147,6 +154,10 @@ public class AmazonConfiguration {
         this.simpleDbRegion = simpleDbRegion;
     }
 
+    public void setCassandraVolumeBlockDevice(String cassandraVolumeBlockDevice) {
+        this.cassandraVolumeBlockDevice = cassandraVolumeBlockDevice;
+    }
+    
     public void discoverConfiguration(AWSCredentialsProvider credentialProvider) {
         if (StringUtils.isBlank(availabilityZone)) {
             availabilityZone = EC2MetadataUtils.getAvailabilityZone();

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamGuiceModule.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamGuiceModule.java
@@ -19,7 +19,6 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
@@ -33,6 +32,8 @@ import com.google.inject.name.Names;
 import com.netflix.priam.aws.AWSMembership;
 import com.netflix.priam.aws.SDBInstanceRegistry;
 import com.netflix.priam.aws.auth.SDBCredentialProvider;
+import com.netflix.priam.volume.DefaultVolumeMetadataManager;
+import com.netflix.priam.volume.IVolumeMetadataManager;
 import com.netflix.priam.config.AmazonConfiguration;
 import com.netflix.priam.config.BackupConfiguration;
 import com.netflix.priam.config.CassandraConfiguration;
@@ -89,6 +90,8 @@ public class PriamGuiceModule extends AbstractModule {
         } else {
             bind(IMembership.class).to(AWSMembership.class).asEagerSingleton();
         }
+
+        bind(IVolumeMetadataManager.class).to(DefaultVolumeMetadataManager.class).asEagerSingleton();
 
         bind(new TypeLiteral<Optional<String>>(){}).annotatedWith(Names.named("awsRoleAssumptionARN")).toInstance(priamConfiguration.getCassandraConfiguration().getSdbRoleAssumptionArn());
         bind(AWSCredentialsProvider.class).to(DefaultAWSCredentialsProviderChain.class).asEagerSingleton();

--- a/priam/src/main/java/com/netflix/priam/utils/RetryableCallable.java
+++ b/priam/src/main/java/com/netflix/priam/utils/RetryableCallable.java
@@ -63,6 +63,8 @@ public abstract class RetryableCallable<T> implements Callable<T> {
                 return retriableCall();
             } catch (CancellationException e) {
                 throw e;
+            } catch (NoMoreRetriesException e) {
+                throw (Exception) e.getCause();
             } catch (Exception e) {
                 retry++;
                 if (retry == retries) {
@@ -81,7 +83,25 @@ public abstract class RetryableCallable<T> implements Callable<T> {
         }
     }
 
+    /**
+     * Helper method to raise an exception and abandon any future retries.  This method return Exception
+     * so it can be part of a <code>throw</code> statement.  This method always throws a
+     * <code>NoMoreRetriesException</code> and never returns.
+     */
+    protected Exception exceptionWithNoRetries(Exception e) throws NoMoreRetriesException {
+        throw new NoMoreRetriesException(e);
+    }
+
     public void forEachExecution() {
         // do nothing by default.
+    }
+
+    /**
+     * Encapsulating exception used to prevent retries.
+     */
+    private static class NoMoreRetriesException extends Exception {
+        public NoMoreRetriesException(Throwable cause) {
+            super(cause);
+        }
     }
 }

--- a/priam/src/main/java/com/netflix/priam/volume/DefaultVolumeMetadataManager.java
+++ b/priam/src/main/java/com/netflix/priam/volume/DefaultVolumeMetadataManager.java
@@ -1,0 +1,135 @@
+package com.netflix.priam.volume;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.AttachmentStatus;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.InstanceBlockDeviceMapping;
+import com.amazonaws.services.ec2.model.Reservation;
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import com.netflix.priam.config.AmazonConfiguration;
+import com.netflix.priam.config.CassandraConfiguration;
+import com.netflix.priam.utils.RetryableCallable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link IVolumeMetadataManager}.  This implementation makes the following assumptions:
+ * <ol>
+ *     <li>
+ *         The Cassandra data location is on an EBS volume.  Because of this assumption it writes a JSON metadata
+ *         file to the data location so that it will always be co-located with the data if the EBS volume is
+ *         transferred to another instance.
+ *     </li>
+ *     <li>
+ *         The block device for the EBS volume has been configured in {@link AmazonConfiguration#cassandraVolumeBlockDevice}.
+ *         This could be introspected from the OS using the Cassandra data location.  However, due to the variance in
+ *         OS distributions and resulting uncertainty this implementation relies on the configuration to explicitly provide
+ *         the block device name (e.g.; "/dev/sdi") and then uses the AWS API to resolve the volume ID from there.
+ *         It is up to the admin to ensure the Cassandra data location is in fact on a directory on the volume mounted
+ *         on that device.
+ *     </li>
+ * </ol>
+ */
+public class DefaultVolumeMetadataManager implements IVolumeMetadataManager {
+
+    private static final String METADATA_FILE_NAME = "priam_volume_metadata.json";
+    private static final Logger logger = LoggerFactory.getLogger(DefaultVolumeMetadataManager.class);
+
+    private final File metadataFile;
+    private final String blockDeviceName;
+    private final AmazonConfiguration amazonConfiguration;
+    private final AWSCredentialsProvider credentialsProvider;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public DefaultVolumeMetadataManager(AmazonConfiguration amazonConfiguration,
+                                        CassandraConfiguration cassandraConfiguration,
+                                        AWSCredentialsProvider credentialsProvider) {
+        this.metadataFile = new File(cassandraConfiguration.getDataLocation(), METADATA_FILE_NAME);
+        this.blockDeviceName = amazonConfiguration.getCassandraVolumeBlockDevice();
+        this.credentialsProvider = credentialsProvider;
+        this.amazonConfiguration = amazonConfiguration;
+        objectMapper = Jackson.getObjectMapper();
+    }
+
+    @Override
+    @Nullable
+    public VolumeMetadata getVolumeMetadata() throws IOException {
+        if (metadataFile.exists()) {
+            try {
+                return objectMapper.readValue(metadataFile, VolumeMetadata.class);
+            } catch (JsonProcessingException e) {
+                logger.warn("EBS volume metadata did not contain valid JSON");
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void setVolumeMetadata(VolumeMetadata volumeMetadata) throws IOException {
+        checkNotNull(volumeMetadata, "volumeMetadata");
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(metadataFile, volumeMetadata);
+    }
+
+    @Override
+    public void clearVolumeMetadata() throws IOException {
+        if (metadataFile.exists()) {
+            if (!metadataFile.delete()) {
+                throw new IOException("Failed to delete volume metadata file");
+            }
+        }
+    }
+
+    @Override
+    @Nullable
+    public String getVolumeID() {
+        try {
+            return new GetVolumeID().call();
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private class GetVolumeID extends RetryableCallable<String> {
+        @Override
+        public String retriableCall() throws Exception {
+            if (blockDeviceName != null) {
+                AmazonEC2 client = new AmazonEC2Client(credentialsProvider);
+                client.setRegion(amazonConfiguration.getRegion());
+                try {
+                    DescribeInstancesRequest desc = new DescribeInstancesRequest().withInstanceIds(amazonConfiguration.getInstanceID());
+                    DescribeInstancesResult res = client.describeInstances(desc);
+
+                    for (Reservation resr : res.getReservations()) {
+                        for (Instance ins : resr.getInstances()) {
+                            for (InstanceBlockDeviceMapping blockDevice : ins.getBlockDeviceMappings()) {
+                                if (blockDeviceName.equals(blockDevice.getDeviceName()) &&
+                                        AttachmentStatus.fromValue(blockDevice.getEbs().getStatus()) == AttachmentStatus.Attached) {
+                                    return blockDevice.getEbs().getVolumeId();
+                                }
+                            }
+                        }
+                    }
+                } finally {
+                    client.shutdown();
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/volume/IVolumeMetadataManager.java
+++ b/priam/src/main/java/com/netflix/priam/volume/IVolumeMetadataManager.java
@@ -1,0 +1,20 @@
+package com.netflix.priam.volume;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+/**
+ * Defining interface for managing metadata about the Cassandra volume.  Although it works in all deploy environments
+ * the real potential comes when the Cassandra data resides on an EBS volume.
+ */
+public interface IVolumeMetadataManager {
+    @Nullable
+    VolumeMetadata getVolumeMetadata() throws IOException;
+
+    void setVolumeMetadata(VolumeMetadata volumeMetadata) throws IOException;
+
+    void clearVolumeMetadata() throws IOException;
+
+    @Nullable
+    String getVolumeID();
+}

--- a/priam/src/main/java/com/netflix/priam/volume/VolumeMetadata.java
+++ b/priam/src/main/java/com/netflix/priam/volume/VolumeMetadata.java
@@ -1,0 +1,61 @@
+package com.netflix.priam.volume;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+/**
+ * Class for holding metadata about the contents of the Cassandra data volume.  This metadata can be used to assist in
+ * transferring EBS volumes between Cassandra instances without the need to re-bootstrap.
+ */
+public class VolumeMetadata {
+
+    @JsonProperty
+    private String volumeId;
+
+    @JsonProperty
+    private String clusterName;
+
+    @JsonProperty
+    private String availabilityZone;
+
+    @JsonProperty
+    private String token;
+
+    @Nullable
+    public String getVolumeId() {
+        return volumeId;
+    }
+
+    public VolumeMetadata setVolumeId(String volumeId) {
+        this.volumeId = volumeId;
+        return this;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public VolumeMetadata setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public VolumeMetadata setAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public VolumeMetadata setToken(String token) {
+        this.token = token;
+        return this;
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/FakeVolumeMetadataManager.java
+++ b/priam/src/test/java/com/netflix/priam/FakeVolumeMetadataManager.java
@@ -1,0 +1,39 @@
+package com.netflix.priam;
+
+import com.netflix.priam.volume.VolumeMetadata;
+import com.netflix.priam.volume.IVolumeMetadataManager;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class FakeVolumeMetadataManager implements IVolumeMetadataManager {
+
+    private VolumeMetadata md;
+    private String volumeId;
+
+    public FakeVolumeMetadataManager(String volumeId) {
+        this.volumeId = volumeId;
+    }
+
+    @Nullable
+    @Override
+    public VolumeMetadata getVolumeMetadata() throws IOException {
+        return md;
+    }
+
+    @Override
+    public void setVolumeMetadata(VolumeMetadata volumeMetadata) throws IOException {
+        md = volumeMetadata;
+    }
+
+    @Override
+    public void clearVolumeMetadata() throws IOException {
+        md = null;
+    }
+
+    @Nullable
+    @Override
+    public String getVolumeID() {
+        return volumeId;
+    }
+}


### PR DESCRIPTION
This PR does the following:

* Creates a file with the EBS volume ID, AWS availability zone, Cassandra cluster name, and Cassandra token in the Cassandra data directory
* When replacing a dead node Priam looks for that file and attempts to choose the dead host which matches the EBS volume content.

The upshot of this is that if a Cassandra instance dies and the replacement instance attaches the same EBS volume from the dead instance then Priam will replace the equivalent host and Cassandra will utilize the existing volume without needing to bootstrap.  
